### PR TITLE
util.zeros() returns undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ exports.elliptic = ec
  * @return {Buffer}
  */
 exports.zeros = function(bytes) {
-  return new Buffer(bytes).fill(0)
+  var buf = new Buffer(bytes);
+  buf.fill(0);
+  return buf;
 }
 
 /**


### PR DESCRIPTION
Hey,

Fix of the error because of which `npm test` fails with the message:
```
  1) zeros function should produce lots of 0s:
     TypeError: Cannot call method 'toString' of undefined
      at Context.<anonymous> (test/index.js:9:22)

  2) pad should pad a Buffer:
     TypeError: Cannot read property 'length' of undefined
      at Buffer.copy (buffer.js:517:13)
      at Object.exports.pad (index.js:43:9)
      at Context.<anonymous> (test/index.js:33:27)
```