### PR TITLE
Add rpad to pad a buffer with trailing zeroes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ pads an `array` or `buffer` with leading zeros till it has `length` bytes
 
 **Return:** `array` or `buffer`
 
+### `rpad(val, length)`
+pads an `array` or `buffer` with trailing zeros till it has `length` bytes  
+**Parameters**
+- `val`  - the value to pad
+- `length` - the of the resulting value
+
+**Return:** `array` or `buffer`
+
 ### `unpad(val)`
 Trims leading zeros from a buffer or an array  
 **Parameters** 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,23 @@ exports.pad = function (msg, length) {
 }
 
 /**
+ * pads an array of buffer with trailing zeros till it has `length` bytes
+ * @method rpad
+ * @param {Buffer|Array} array
+ * @param {Integer}  length the number of bytes the output should be
+ * @return {Buffer|Array}
+ */
+exports.rpad = function (msg, length) {
+  msg = exports.toBuffer(msg)
+  if (msg.length < length) {
+    var buf = exports.zeros(length)
+    msg.copy(buf)
+    return buf
+  }
+  return msg.slice(-length)
+}
+
+/**
  * Trims leading zeros from a buffer or an array
  *
  * @method unpad

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,14 @@ describe('pad', function () {
   })
 })
 
+describe('rpad', function () {
+  it('should right pad a Buffer', function () {
+    var buf = new Buffer([9, 9])
+    var padded = ethUtils.rpad(buf, 3)
+    assert.equal(padded.toString('hex'), '090900')
+  })
+})
+
 describe('intToHex', function () {
   it('should convert a int to hex', function () {
     var i = 6003400


### PR DESCRIPTION
Useful for handling the ```bytes``` type in the ABI. I'm using it [here](https://github.com/axic/ethereumjs-abi).