### PR TITLE
Add rlphash() as a shorthand to hashing RLP encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ Returns a ripemd160 of `a`
 
 **Return:** `Buffer`
 
+### `rlphash(a)`
+Returns a sha3 of the RLP encoded version of `a`
+**Parameters**
+- `a` - the value to encode and hash
+
+**Return:** `Buffer`
+
 ### `printBA(ba)`
 Print a Buffer Array  
 **Parameters**   

--- a/index.js
+++ b/index.js
@@ -226,6 +226,16 @@ exports.ripemd160 = function (a, padded) {
 }
 
 /**
+ * Creates SHA-3 hash of the RLP encoded version of the input
+ * @method rlphash
+ * @param {Buffer|Array|String|Number} a the input data
+ * @return {Buffer}
+ */
+exports.rlphash = function (a) {
+  return exports.sha3(rlp.encode(a))
+}
+
+/**
  * Returns the ethereum address of a given public key
  * @method pubToAddress
  * @param {Buffer}

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,15 @@ describe('ripemd160', function () {
   })
 })
 
+describe('rlphash', function () {
+  it('should produce a sha3 of the rlp data', function () {
+    var msg = '0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1'
+    var r = '33f491f24abdbdbf175e812b94e7ede338d1c7f01efb68574acd279a15a39cbe'
+    var hash = ethUtils.rlphash(msg)
+    assert.equal(hash.toString('hex'), r)
+  })
+})
+
 describe('unpad', function () {
   it('should unpad a string', function () {
     var str = '0000000006600'


### PR DESCRIPTION
This is duplicated in ```ethereumjs-block```, ```ethereumjs-tx``` and ```ethashjs```.